### PR TITLE
Prompt for separator

### DIFF
--- a/autoload/operator/sort.vim
+++ b/autoload/operator/sort.vim
@@ -26,6 +26,7 @@ function! operator#sort#sort(motion_wiseness)  "{{{2
   if a:motion_wiseness == 'char'
     let reg_0 = [@0, getregtype('0')]
 
+    echo "Separator?"
     normal! `[v`]"0y
     let separator = escape(nr2char(getchar()), '\')
     let [xs, ys] = s:partition(@0, '\V\[\n ]\*' . separator . '\[\n ]\*')


### PR DESCRIPTION
I found it very confusing why I did the operator and vim was waiting for another command. echo'ing a prompt seems helpful but also ignorable -- no "press enter" or anything.

Make it clear why there's a second character required. Useful if you
don't use this command often.