### PR TITLE
Add sort-operator-numeric

### DIFF
--- a/autoload/operator/sort.vim
+++ b/autoload/operator/sort.vim
@@ -36,16 +36,16 @@ function! operator#sort#sort(motion_wiseness)  "{{{2
 
     call setreg('0', reg_0[0], reg_0[1])
   else  " line or block
-    '[,']sort
+    exec "'[,']sort" s:sort_mode
   endif
 endfunction
 
 
 
 
-" Misc.  "{{{1
-function! s:compare(x, y)  "{{{2
-  if a:x == '' || a:y == ''
+" Comparison  "{{{1
+function! s:compare_modeless(x, y)  "{{{2
+  if a:x == a:y
     return 0
   elseif a:x > a:y
     return 1
@@ -53,6 +53,28 @@ function! s:compare(x, y)  "{{{2
   return -1
 endfunction
 
+
+function! s:is_num(x) abort  "{{{2
+  return a:x =~# '^\d\+'
+endf
+
+
+function! s:compare(x, y)  "{{{2
+  if a:x == '' || a:y == ''
+    return 0
+  elseif s:sort_mode == 'n' && s:is_num(a:x) && s:is_num(a:y)
+    " Non numbers will return 0. Seems good enough.
+    return s:compare_modeless(str2nr(a:x), str2nr(a:y))
+  end
+  return s:compare_modeless(a:x, a:y)
+endfunction
+
+
+
+" Misc.  "{{{1
+function! operator#sort#set_mode(mode)  "{{{2
+  let s:sort_mode = a:mode
+endfunction
 
 
 

--- a/autoload/operator/sort.vim
+++ b/autoload/operator/sort.vim
@@ -45,7 +45,12 @@ endfunction
 
 " Misc.  "{{{1
 function! s:compare(x, y)  "{{{2
-  return a:x == '' || a:y == '' ? 0 : a:x > a:y ? 1 : -1
+  if a:x == '' || a:y == ''
+    return 0
+  elseif a:x > a:y
+    return 1
+  end
+  return -1
 endfunction
 
 

--- a/plugin/operator/sort.vim
+++ b/plugin/operator/sort.vim
@@ -29,7 +29,8 @@ endif
 
 
 
-call operator#user#define('sort', 'operator#sort#sort')
+call operator#user#define('sort', 'operator#sort#sort', 'call operator#sort#set_mode("")')
+call operator#user#define('sort-numeric', 'operator#sort#sort', 'call operator#sort#set_mode("n")')
 
 
 


### PR DESCRIPTION
`:sort n` is very useful, so support another operator to perform numeric sorts.

It's complicated to support `:sort n`-style numeric sort char-wise,
but very simple and useful to support it line-wise. So do a basic
version for char-wise that sorts two numbers as numbers.

Changes the sort to be stable since characters after a number make sorted
objects not uniquely identified by the sort key (the number).

Using `<Plug>(sort-operator-numeric)ib,` we get:

    (bb, aa, 45, cc, 54, 5, 39, 40aa, -10)
sorted to:
    (-10, 5, 39, 40aa, 45, 54, aa, bb, cc)
sorted to:
    (-10, 5, 39, 40aa, 45, 54, aa, bb, cc)

The sort is stable, sorts both strings and numbers, and positions
strings at the end.

`:sort n` would give:
    bb, aa, cc, -10, 5, 39, 40aa, 45, 54,

So the number section is identical, but the string section is at the
other end and sort-operator-numeric sorts it.

In contrast, using `<Plug>(sort-operator)ib,` we get:

    (bb, aa, 45, cc, 54, 5, 39, 40aa, -10)
sorted to:
    (-10, 39, 40aa, 45, 5, 54, aa, bb, cc)
sorted to:
    (-10, 39, 40aa, 45, 5, 54, aa, bb, cc)

Unsurprising, identical results to `:sort`.


See the last few [commits in numeric-options](https://github.com/idbrii/vim-operator-sort/commits/numeric-options) for alternative behaviours, but I thought sorting the numbers separately from the strings seemed like the best solution.